### PR TITLE
Updated Dockerfile, outputFile mode 0644

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
+FROM golang:1.13-alpine as builder
+
+RUN apk add --no-cache git gcc libc-dev
+
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV CGO_ENABLED=0
+
+COPY $PWD/ /go/src/app/
+WORKDIR /go/src/app/
+
+RUN go get app && go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /go/bin/prometheus-digitalocean-sd
+
+# Final image
 FROM gcr.io/distroless/base
-COPY prometheus-digitalocean-sd /prometheus-digitalocean-sd
+
+COPY --from=builder /go/bin/prometheus-digitalocean-sd /prometheus-digitalocean-sd
+
 ENTRYPOINT ["/prometheus-digitalocean-sd"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,4 @@
-FROM golang:1.13-alpine as builder
-
-RUN apk add --no-cache git gcc libc-dev
-
-ENV GOOS=linux
-ENV GOARCH=amd64
-ENV CGO_ENABLED=0
-
-COPY $PWD/ /go/src/app/
-WORKDIR /go/src/app/
-
-RUN go get app && go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /go/bin/prometheus-digitalocean-sd
-
-# Final image
 FROM gcr.io/distroless/base
-
-COPY --from=builder /go/bin/prometheus-digitalocean-sd /prometheus-digitalocean-sd
-
+COPY prometheus-digitalocean-sd /prometheus-digitalocean-sd
 ENTRYPOINT ["/prometheus-digitalocean-sd"]
 

--- a/main.go
+++ b/main.go
@@ -147,8 +147,13 @@ func write(data []Target) error {
 	if err != nil {
 		return errors.Wrap(err, "could not  write to temp file")
 	}
+
 	defer log.Println("written", *outputFile)
-	return os.Rename(tmpfile.Name(), *outputFile)
+	if err := os.Rename(tmpfile.Name(), *outputFile); err != nil {
+		log.Fatal(err)
+	}
+	// Set file mode to '0644' instead of '0600' by default for tmpfile
+	return os.Chmod(*outputFile, 0644)
 }
 
 // Target is a target that marshal into the file_sd prometheus json format


### PR DESCRIPTION
Updated Dockerfile with Go build stage.
The default output file mode is `0600` (as for temp file) cannot be read by Prometheus - error arises. Changed to 0644.